### PR TITLE
Update Specs Processing

### DIFF
--- a/src/utils/funcs.ts
+++ b/src/utils/funcs.ts
@@ -48,7 +48,6 @@ export const parseSpecializations = (input: any): { name: string, detail: string
 
   while (input[`spec_${index}_name`] && input[`spec_${index}_detail`]) {
     result.push({ name: input[`spec_${index}_name`], detail: input[`spec_${index}_detail`] });
-
     index += 1;
   }
 


### PR DESCRIPTION
I removed the hardcoded number of major specializations, it now loads all specializations as long as all both fields are found in the spreadsheet.